### PR TITLE
Fix unnecessary di for dictionary service

### DIFF
--- a/packages/node/src/indexer/dictionary.service.ts
+++ b/packages/node/src/indexer/dictionary.service.ts
@@ -9,7 +9,7 @@ import {
   gql,
   ApolloLink,
 } from '@apollo/client/core';
-import { Injectable, OnApplicationShutdown } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { authHttpLink } from '@subql/apollo-links';
 import {
   getLogger,
@@ -155,7 +155,7 @@ export class DictionaryService implements OnApplicationShutdown {
   protected _startHeight: number;
 
   constructor(
-    protected project: SubqueryProject,
+    @Inject('ISubqueryProject') private readonly project: SubqueryProject,
     protected readonly nodeConfig: NodeConfig,
     protected readonly metadataKeys = ['lastProcessedHeight', 'genesisHash'], // Cosmos uses chain instead of genesisHash
   ) {

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -204,16 +204,17 @@ export class FetchService implements OnApplicationShutdown {
     });
     await this.getLatestRound();
 
-    //  Call metadata here, other network should align with this
-    //  For substrate, we might use the specVersion metadata in future if we have same error handling as in node-core
-    const metadata = await this.dictionaryService.getMetadata();
+    if (this.project.network.dictionary) {
+      //  Call metadata here, other network should align with this
+      //  For substrate, we might use the specVersion metadata in future if we have same error handling as in node-core
+      const metadata = await this.dictionaryService.getMetadata();
+      const validChecker = this.dictionaryValidation(metadata);
 
-    const validChecker = this.dictionaryValidation(metadata);
-
-    if (validChecker) {
-      this.dictionaryService.setDictionaryStartHeight(
-        metadata._metadata.startHeight,
-      );
+      if (validChecker) {
+        this.dictionaryService.setDictionaryStartHeight(
+          metadata._metadata.startHeight,
+        );
+      }
     }
 
     await this.blockDispatcher.init(this.resetForNewDs.bind(this));

--- a/packages/node/src/indexer/indexer.module.ts
+++ b/packages/node/src/indexer/indexer.module.ts
@@ -11,7 +11,6 @@ import {
 } from '@subql/node-core';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { ApiService } from './api.service';
-import { DictionaryService } from './dictionary.service';
 import { DsProcessorService } from './ds-processor.service';
 import { DynamicDsService } from './dynamic-ds.service';
 import { IndexerManager } from './indexer.manager';
@@ -32,7 +31,6 @@ import { WorkerService } from './worker/worker.service';
       },
       inject: ['ISubqueryProject', EventEmitter2, NodeConfig],
     },
-    DictionaryService,
     SandboxService,
     DsProcessorService,
     DynamicDsService,


### PR DESCRIPTION
# Description
Fixes issue of failing to inject DictionaryService with workers. The dictionary service wasn't needed. 

Also stopped getting dictionary metadata if there is no endpoint provided

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
