### PR TITLE
Improvements to filtering and data types

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,3 +21,4 @@ Please delete options that are not relevant.
 - [ ] I have added tests relevant to my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
 - [ ] My code is up to date with the base branch
+- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)

--- a/packages/common-algorand/CHANGELOG.md
+++ b/packages/common-algorand/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `applicationArgs` to `AlgorandTransactionFilter` (#67)
 
 ## [2.3.0] - 2023-06-27
 ### Changed

--- a/packages/common-algorand/src/project/models.ts
+++ b/packages/common-algorand/src/project/models.ts
@@ -85,6 +85,11 @@ export class TransactionFilter implements AlgorandTransactionFilter {
   @IsOptional()
   @ValidateIf((o: TransactionFilter) => o.txType === TransactionType.appl)
   applicationId?: number;
+
+  @IsString()
+  @IsOptional()
+  @ValidateIf((o: TransactionFilter) => o.txType === TransactionType.appl)
+  applicationArgs?: string[];
 }
 
 export class BlockHandler implements AlgorandBlockHandler {

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `block` to `AlgorandTransaction` (#67)
+- Add `getTransactionsByGroup` to `AlgorandBlock` (#67)
+- Add `applicationArgs` to `AlgorandTransactionFilter`. Note: dictionary doesn't yet support this. (#67)
+### Changed
+- Reduce block time interval (#67)
 
 ## [2.8.0] - 2023-06-27
 ### Changed

--- a/packages/node/src/algorand/algorand.spec.ts
+++ b/packages/node/src/algorand/algorand.spec.ts
@@ -145,6 +145,8 @@ describe('Algorand RPC', () => {
     // We can stringify the objects
     expect(() => JSON.stringify(block)).not.toThrow();
     expect(() => JSON.stringify(block.transactions[13])).not.toThrow();
+
+    expect(JSON.parse(JSON.stringify(block)).round).toEqual(block.round);
   });
 
   it('can get the grouped transactions within a block', async () => {

--- a/packages/node/src/algorand/algorand.spec.ts
+++ b/packages/node/src/algorand/algorand.spec.ts
@@ -4,17 +4,25 @@
 import { INestApplication } from '@nestjs/common';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Test } from '@nestjs/testing';
-import { ConnectionPoolService, NodeConfig } from '@subql/node-core';
+import {
+  ApiService,
+  ConnectionPoolService,
+  NodeConfig,
+} from '@subql/node-core';
 import { GraphQLSchema } from 'graphql';
 import { AlgorandApiService, filterTransaction } from '../algorand';
 import { SubqueryProject } from '../configure/SubqueryProject';
 
-const testNetEndpoint = 'https://algoindexer.testnet.algoexplorerapi.io';
+const mainnetEndpoint = 'https://mainnet-idx.algonode.cloud/';
+const testnetEndpoint = 'https://testnet-idx.algonode.cloud';
 
-function testSubqueryProject(endpoint: string): SubqueryProject {
+const mainnetChainId = 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=';
+const testnetChainId = 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=';
+
+function testSubqueryProject(endpoint: string, chainId): SubqueryProject {
   return {
     network: {
-      chainId: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
+      chainId,
       endpoint,
       dictionary: `https://api.subquery.network/sq/subquery/Algorand-Dictionary`,
     },
@@ -26,34 +34,36 @@ function testSubqueryProject(endpoint: string): SubqueryProject {
   };
 }
 
+export const prepareApiService = async (
+  endpoint: string = mainnetEndpoint,
+  chainId: string = mainnetChainId,
+): Promise<[INestApplication, AlgorandApiService]> => {
+  const module = await Test.createTestingModule({
+    providers: [
+      {
+        provide: 'ISubqueryProject',
+        useFactory: () => testSubqueryProject(endpoint, chainId),
+      },
+      NodeConfig,
+      ConnectionPoolService,
+      AlgorandApiService,
+    ],
+    imports: [EventEmitterModule.forRoot()],
+  }).compile();
+
+  const app = module.createNestApplication();
+  await app.init();
+  const apiService = app.get(AlgorandApiService);
+  await apiService.init();
+  return [app, apiService];
+};
+
 jest.setTimeout(90000);
 describe('Algorand RPC', () => {
   let app: INestApplication;
+  let apiService: ApiService;
 
-  const prepareApiService = async (
-    endpoint: string = testNetEndpoint,
-  ): Promise<AlgorandApiService> => {
-    const module = await Test.createTestingModule({
-      providers: [
-        {
-          provide: 'ISubqueryProject',
-          useFactory: () => testSubqueryProject(endpoint),
-        },
-        NodeConfig,
-        ConnectionPoolService,
-        AlgorandApiService,
-      ],
-      imports: [EventEmitterModule.forRoot()],
-    }).compile();
-
-    app = module.createNestApplication();
-    await app.init();
-    const apiService = app.get(AlgorandApiService);
-    await apiService.init();
-    return apiService;
-  };
-
-  afterAll(() => {
+  afterEach(() => {
     return app?.close();
   });
 
@@ -107,20 +117,43 @@ describe('Algorand RPC', () => {
       }),
     ).toBe(true);
   });
-  it('paginate large blocks', async () => {
-    const apiService = await prepareApiService();
+
+  // This is failing since switching from algo explorer api. This is due to a node configuration limit
+  it.skip('paginate large blocks', async () => {
+    [app, apiService] = await prepareApiService(
+      testnetEndpoint,
+      testnetChainId,
+    );
     const failingBlock = 27739202; // testnet
     const passingBlock = 27739200; // testnet
     const api = apiService.api;
 
     const paginateSpy = jest.spyOn(api, 'paginatedTransactions');
-    const fetchBlock = async () => {
-      // return api.getBlockByHeight(passingBlock);
-      return api.getBlockByHeight(failingBlock);
-    };
-
-    const result = await fetchBlock();
+    const result = await api.getBlockByHeight(failingBlock)();
     expect(paginateSpy).toHaveBeenCalledTimes(3);
     expect(result.transactions.length).toEqual(13916);
+  });
+
+  it('can stringify blocks and transactions with circular references', async () => {
+    [app, apiService] = await prepareApiService();
+
+    const block = await apiService.api.getBlockByHeight(30478896);
+
+    // The circular ref
+    expect(block.transactions[13].block).toBeDefined();
+
+    // We can stringify the objects
+    expect(() => JSON.stringify(block)).not.toThrow();
+    expect(() => JSON.stringify(block.transactions[13])).not.toThrow();
+  });
+
+  it('can get the grouped transactions within a block', async () => {
+    [app, apiService] = await prepareApiService();
+
+    const block = await apiService.api.getBlockByHeight(30478896);
+
+    const groupTx = block.getTransactionsByGroup(block.transactions[13].group);
+
+    expect(groupTx.length).toEqual(3);
   });
 });

--- a/packages/node/src/algorand/api.algorand.ts
+++ b/packages/node/src/algorand/api.algorand.ts
@@ -10,6 +10,7 @@ import {
 } from '@subql/types-algorand';
 import algosdk, { Indexer } from 'algosdk';
 import axios from 'axios';
+import { omit } from 'lodash';
 import { camelCaseObjectKey } from './utils.algorand';
 
 const logger = getLogger('api.algorand');
@@ -42,7 +43,7 @@ export class AlgorandApi {
   async getBlockByHeight(height: number): Promise<AlgorandBlock> {
     try {
       const blockInfo = await this.api.lookupBlock(height).do();
-      return camelCaseObjectKey(blockInfo);
+      return this.constructBlock(camelCaseObjectKey(blockInfo));
     } catch (error) {
       if (error.message.includes('Max transactions limit exceeded')) {
         logger.warn('Max transactions limit exceeded, paginating transactions');
@@ -117,13 +118,38 @@ export class AlgorandApi {
         this.getHeaderOnly(blockHeight),
         this.paginatedTransactions(blockHeight),
       ]);
-      const header = camelCaseObjectKey(blockHeader);
-      header.transactions = camelCaseObjectKey(paginatedTransactionsResults);
-      return header;
+
+      return this.constructBlock({
+        ...camelCaseObjectKey(blockHeader),
+        transactions: camelCaseObjectKey(paginatedTransactionsResults),
+      });
     } catch (e) {
       logger.error(`Failed to paginate round ${blockHeight}`);
       throw e;
     }
+  }
+
+  private constructBlock(block: AlgorandBlock): AlgorandBlock {
+    const newBlock = {
+      ...block,
+      getTransactionsByGroup: (groupId: string) =>
+        transactions.filter((tx) => tx.group === groupId),
+      toJSON(): string {
+        return JSON.stringify(omit(this, ['getTransactionsByGroup', 'toJSON']));
+      },
+    };
+    const transactions = newBlock.transactions.map((tx) => ({
+      ...tx,
+      block: newBlock,
+      toJSON(): string {
+        return JSON.stringify(omit(this, ['block', 'toJSON']));
+      },
+    }));
+
+    // Update transactions
+    newBlock.transactions = transactions;
+
+    return newBlock;
   }
 
   async fetchBlocksArray(blockArray: number[]): Promise<any[]> {

--- a/packages/node/src/algorand/api.algorand.ts
+++ b/packages/node/src/algorand/api.algorand.ts
@@ -134,15 +134,15 @@ export class AlgorandApi {
       ...block,
       getTransactionsByGroup: (groupId: string) =>
         transactions.filter((tx) => tx.group === groupId),
-      toJSON(): string {
-        return JSON.stringify(omit(this, ['getTransactionsByGroup', 'toJSON']));
+      toJSON() {
+        return omit(this, ['getTransactionsByGroup', 'toJSON']);
       },
     };
     const transactions = newBlock.transactions.map((tx) => ({
       ...tx,
       block: newBlock,
-      toJSON(): string {
-        return JSON.stringify(omit(this, ['block', 'toJSON']));
+      toJSON() {
+        return omit(this, ['block', 'toJSON']);
       },
     }));
 

--- a/packages/node/src/algorand/utils.algorand.spec.ts
+++ b/packages/node/src/algorand/utils.algorand.spec.ts
@@ -1,0 +1,85 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { INestApplication } from '@nestjs/common';
+import { AlgorandBlock } from '@subql/types-algorand';
+import { prepareApiService } from './algorand.spec';
+import { AlgorandApiService } from './api.service.algorand';
+import { filterTransaction } from './utils.algorand';
+
+describe('Algorand Filters', () => {
+  describe('Transaction Filters', () => {
+    let app: INestApplication;
+    let api: AlgorandApiService;
+    let block: AlgorandBlock;
+
+    beforeAll(async () => {
+      [app, api] = await prepareApiService();
+
+      block = await api.api.getBlockByHeight(30478896);
+    });
+
+    afterAll(async () => {
+      await app?.close();
+    });
+
+    it('returns true with no filter', () => {
+      expect(filterTransaction(block.transactions[13])).toBeTruthy();
+    });
+
+    it('can fillter by sender', () => {
+      expect(
+        filterTransaction(block.transactions[13], {
+          sender: '5GMADASEGJ324HR4GI2XZ2BNSN77ND45LLF4F4XDTAYX3YM6TX5YEU4FEA',
+        }),
+      ).toBeTruthy();
+      expect(
+        filterTransaction(block.transactions[13], { sender: 'WRONG_ADDRESSS' }),
+      ).toBeFalsy();
+    });
+
+    it('can fillter by receiver', () => {
+      expect(
+        filterTransaction(block.transactions[18], {
+          receiver:
+            'V6CK3HRC4JBRBDIBB4JWOBMYNUYIP7SYHRPVHH5ZMJQME337C57IBIZVFI',
+        }),
+      ).toBeTruthy();
+      expect(
+        filterTransaction(block.transactions[18], {
+          receiver: 'WRONG_ADDRESSS',
+        }),
+      ).toBeFalsy();
+    });
+
+    it('can fillter by application id', () => {
+      expect(
+        filterTransaction(block.transactions[13], { applicationId: 971368268 }),
+      ).toBeTruthy();
+      expect(
+        filterTransaction(block.transactions[13], { applicationId: 0 }),
+      ).toBeFalsy();
+    });
+
+    it('can fillter by application args', () => {
+      // Filter single argument (function signature)
+      expect(
+        filterTransaction(block.transactions[13], {
+          applicationArgs: ['udVC+w=='],
+        }),
+      ).toBeTruthy();
+      // Filter all arguments
+      expect(
+        filterTransaction(block.transactions[13], {
+          applicationArgs: ['udVC+w==', 'AQ==', 'AA==', 'AQ==', 'AQ=='],
+        }),
+      ).toBeTruthy();
+      // Filter specific argument
+      expect(
+        filterTransaction(block.transactions[13], {
+          applicationArgs: ['udVC+w==', null, null, null, 'AQ=='],
+        }),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/packages/node/src/algorand/utils.algorand.ts
+++ b/packages/node/src/algorand/utils.algorand.ts
@@ -28,7 +28,7 @@ export function camelCaseObjectKey(object: object) {
 
 export function calcInterval(api: Indexer): number {
   // Pulled from https://metrics.algorand.org/#/protocol/#blocks
-  return 4300;
+  return 3300;
 }
 
 export const mappingFilterTransaction = {
@@ -56,6 +56,7 @@ export const mappingFilterTransaction = {
   },
   [TransactionType.appl]: {
     applicationId: 'applicationTransaction.applicationId',
+    applicationArgs: 'applicationTransaction.applicationArgs',
     sender: 'sender',
   },
 };
@@ -79,6 +80,26 @@ export function filterBlockModulo(
   return block.round % modulo === 0;
 }
 
+function txComparator(a: any, b: any): boolean {
+  if (Array.isArray(a)) {
+    for (let i = 0; i < a.length; i++) {
+      const valA = a[i];
+      const valB = b[i];
+
+      if (valA === null) {
+        continue;
+      }
+
+      if (valA !== valB) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return a === b;
+}
+
 export function filterTransaction(
   txn: AlgorandTransaction,
   filter?: AlgorandTransactionFilter,
@@ -91,7 +112,11 @@ export function filterTransaction(
   for (const key in filterByKey) {
     if (
       mappingFilterTransaction[txn.txType] &&
-      filterByKey[key] !== get(txn, mappingFilterTransaction[txn.txType][key])
+      !txComparator(
+        filterByKey[key],
+        get(txn, mappingFilterTransaction[txn.txType][key]),
+      )
+      // filterByKey[key] !== get(txn, mappingFilterTransaction[txn.txType][key])
     ) {
       return false;
     }

--- a/packages/node/src/algorand/utils.algorand.ts
+++ b/packages/node/src/algorand/utils.algorand.ts
@@ -80,24 +80,24 @@ export function filterBlockModulo(
   return block.round % modulo === 0;
 }
 
-function txComparator(a: any, b: any): boolean {
-  if (Array.isArray(a)) {
-    for (let i = 0; i < a.length; i++) {
-      const valA = a[i];
-      const valB = b[i];
+function txComparator(filter: any, data: any): boolean {
+  if (Array.isArray(filter)) {
+    for (let i = 0; i < filter.length; i++) {
+      const valFilter = filter[i];
+      const valData = data[i];
 
-      if (valA === null) {
+      if (valFilter === null) {
         continue;
       }
 
-      if (valA !== valB) {
+      if (valFilter !== valData) {
         return false;
       }
     }
     return true;
   }
 
-  return a === b;
+  return filter === data;
 }
 
 export function filterTransaction(

--- a/packages/node/src/indexer/fetch.service.ts
+++ b/packages/node/src/indexer/fetch.service.ts
@@ -116,13 +116,13 @@ export class FetchService extends BaseFetchService<
             break;
           case AlgorandHandlerKind.Transaction:
             filterList.forEach((f) => {
-              const conditions: DictionaryQueryCondition[] = Object.entries(
-                f,
-              ).map(([field, value]) => ({
-                field,
-                value,
-                matcher: 'equalTo',
-              }));
+              const conditions: DictionaryQueryCondition[] = Object.entries(f)
+                .filter(([field]) => field !== 'applicationArgs') // Dictionary doesn't support applciation args
+                .map(([field, value]) => ({
+                  field,
+                  value,
+                  matcher: 'equalTo',
+                }));
               queryEntries.push({
                 entity: 'transactions',
                 conditions,

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 All logs must start with the format: [x.y.z] - yyyy-mm-dd
 
 ## [Unreleased]
+### Added
+- Add `block` to `AlgorandTransaction` (#67)
+- Add `getTransactionsByGroup` to `AlgorandBlock` (#67)
+- Add `applicationArgs` to `AlgorandTransactionFilter` (#67)
 
 ## [2.1.0] - 2023-05-17
-### Updated
+### Changed
 - Sync with main SDK
 
 ## [2.0.0] - 2023-05-01
@@ -18,15 +22,14 @@ All logs must start with the format: [x.y.z] - yyyy-mm-dd
 - Sync with main SDK for 2.0 release
 
 ## [1.6.0] - 2023-02-21
-### Updated
+### Changed
 - Sync with main sdk
   - Add `count` to `Store` interface
   - Support for `bypassBlocks`
 
 ## [1.5.0] - 2023-01-24
 ### Added
-* Add `count` function to get the number of entities (#22)
-
+- Add `count` function to get the number of entities (#22)
 
 ## [1.4.0] - 2022-11-11
 ### Changed
@@ -40,13 +43,21 @@ Sync changes from main SDK:
 - Added `bulkUpdate` and `bulkGet` to the injected store. This can be used to optimise handlers and speed up indexing.
 
 ## [1.2.1] - 2022-08-04
+### Fixed
 No Changes, fixing build issue
 
 ## [1.2.0] - 2022-08-04
+### Changed
 Initial Algorand support
 
-[Unreleased]: https://github.com/subquery/subql/compare/types/v1.3.0...HEAD
-[1.2.1]: https://github.com/subquery/subql/compare/types/v1.2.1...types/v1.3.0
-[1.2.1]: https://github.com/subquery/subql/compare/types/v1.2.0...types/v1.2.1
-[1.2.0]: https://github.com/subquery/subql/compare/types/v1.2.0
+[Unreleased]: https://github.com/subquery/subql-algorand/compare/types/2.1.0...HEAD
+[2.1.0]: https://github.com/subquery/subql-algorand/compare/types/2.0.0...types/2.1.0
+[2.0.0]: https://github.com/subquery/subql-algorand/compare/types/1.6.0...types/2.0.0
+[1.6.0]: https://github.com/subquery/subql-algorand/compare/types/1.5.0...types/1.6.0
+[1.5.0]: https://github.com/subquery/subql-algorand/compare/types/1.4.0...types/1.5.0
+[1.4.0]: https://github.com/subquery/subql-algorand/compare/types/1.3.0...types/1.4.0
+[1.3.0]: https://github.com/subquery/subql-algorand/compare/types/1.2.1...types/1.3.0
+[1.2.1]: https://github.com/subquery/subql-algorand/compare/types/1.2.1...types/1.3.0
+[1.2.1]: https://github.com/subquery/subql-algorand/compare/types/1.2.0...types/1.2.1
+[1.2.0]: https://github.com/subquery/subql-algorand/tag/types/1.2.0
 

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -202,6 +202,7 @@ export interface AlgorandTransaction {
   senderRewards?: number;
   signature?: TransactionSignature;
   txType: TransactionType;
+  block: AlgorandBlock;
 }
 
 export interface AlgorandBlock {
@@ -218,6 +219,7 @@ export interface AlgorandBlock {
   txnCounter?: number;
   upgradeState?: BlockUpgradeState;
   upgradeVote?: BlockUpgradeVote;
+  getTransactionsByGroup: (groupId: string) => AlgorandTransaction[];
 }
 
 export type SafeAPI = {

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -59,6 +59,7 @@ export interface AlgorandTransactionFilter {
   newFreezeStatus?: boolean;
   address?: string;
   applicationId?: number;
+  applicationArgs?: string[];
 }
 
 export type AlgorandBlockHandler = AlgorandCustomHandler<AlgorandHandlerKind.Block, AlgorandBlockFilter>;


### PR DESCRIPTION
# Description
- Adds `AlgorandTransaction.block` to get the block and other transactions for a block
- Adds `AlgorandBlock.getTransactionsByGroup` to find relevant transactions
- Reduces the block interval from 4.3s to 3.3s
- Adds `applicationArgs` filter option. This filter has not been applied to the dictionary so it may not be as performant as expected. You can use `null` to skip validating arguments.

Fixes https://github.com/subquery/subql-algorand/issues/65

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update https://github.com/subquery/documentation/pull/373

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation https://github.com/subquery/documentation/pull/373
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
