### PR TITLE
Fix algorand using wrong value for block hash

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- POI throwing an error due to incorrect block hash (#120)
 
 ## [3.11.2] - 2024-05-02
 ### Fixed

--- a/packages/node/src/algorand/utils.algorand.ts
+++ b/packages/node/src/algorand/utils.algorand.ts
@@ -16,7 +16,7 @@ import { BlockContent } from '../indexer/types';
 export function algorandBlockToHeader(block: BlockContent): Header {
   return {
     blockHeight: block.round,
-    blockHash: block.round.toString(),
+    blockHash: block.hash,
     parentHash: block.previousBlockHash,
   };
 }


### PR DESCRIPTION
# Description
For some reason round as a string was used for the block hash, this now corrects this which in turn fixes POI because it was unable to work correctly with a number

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
