### PR TITLE
Fix timestamp parsing in block header

### DIFF
--- a/packages/node/src/algorand/utils.algorand.spec.ts
+++ b/packages/node/src/algorand/utils.algorand.spec.ts
@@ -5,7 +5,7 @@ import { INestApplication } from '@nestjs/common';
 import { AlgorandBlock } from '@subql/types-algorand';
 import { prepareApiService } from './algorand.spec';
 import { AlgorandApiService } from './api.service.algorand';
-import { filterTransaction } from './utils.algorand';
+import { algorandBlockToHeader, filterTransaction } from './utils.algorand';
 
 describe('Algorand Filters', () => {
   describe('Transaction Filters', () => {
@@ -93,6 +93,12 @@ describe('Algorand Filters', () => {
           receiver: undefined,
         }),
       ).toBeTruthy();
+    });
+
+    it('can correctly get a block timestamp date', () => {
+      const header = algorandBlockToHeader(block);
+
+      expect(header.timestamp).toEqual(new Date('2023-07-13T10:44:35.000Z'));
     });
   });
 });

--- a/packages/node/src/algorand/utils.algorand.ts
+++ b/packages/node/src/algorand/utils.algorand.ts
@@ -18,7 +18,7 @@ export function algorandBlockToHeader(block: BlockContent): Header {
     blockHeight: block.round,
     blockHash: block.hash,
     parentHash: block.previousBlockHash,
-    timestamp: new Date(block.timestamp),
+    timestamp: new Date(block.timestamp * 1000), // Add MS
   };
 }
 


### PR DESCRIPTION
# Description
Algorand block timestamps do not include MS so when converting to a date it would produce an incorrect time. This has now been fiexed by adding MS.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Algorand block timestamp conversion so block times are interpreted correctly (seconds→milliseconds), ensuring displayed timestamps are accurate.

* **Tests**
  * Added a test validating Algorand block timestamp conversion to prevent regressions and ensure consistent timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->