### PR TITLE
[release] 20251103

### DIFF
--- a/packages/common-algorand/CHANGELOG.md
+++ b/packages/common-algorand/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@subql/common` (#161)
 
 ## [4.4.3] - 2025-07-01
 ### Changed

--- a/packages/common-algorand/CHANGELOG.md
+++ b/packages/common-algorand/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.4.4] - 2025-11-03
 ### Changed
 - Update `@subql/common` (#161)
 
@@ -143,7 +145,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `assetId` on transaction filter being validated as a string. (#9)
 
 ## [1.0.0] - 2022-08-04
-[Unreleased]: https://github.com/subquery/subql-algorand/compare/common-algorand/4.4.3...HEAD
+[Unreleased]: https://github.com/subquery/subql-algorand/compare/common-algorand/4.4.4...HEAD
+[4.4.4]: https://github.com/subquery/subql-algorand/compare/common-algorand/4.4.3...common-algorand/4.4.4
 [4.4.3]: https://github.com/subquery/subql-algorand/compare/common-algorand/4.4.2...common-algorand/4.4.3
 [4.4.2]: https://github.com/subquery/subql-algorand/compare/common-algorand/4.4.1...common-algorand/4.4.2
 [4.4.1]: https://github.com/subquery/subql-algorand/compare/common-algorand/4.4.0...common-algorand/4.4.1

--- a/packages/common-algorand/package.json
+++ b/packages/common-algorand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/common-algorand",
-  "version": "4.4.4-0",
+  "version": "4.4.4",
   "description": "",
   "scripts": {
     "build": "rm -rf dist && tsc -b",
@@ -41,6 +41,5 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE"
-  ],
-  "stableVersion": "4.4.3"
+  ]
 }

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@subql/common`, `@subql/node-core`  (#161)
 
 ## [4.0.3] - 2025-07-01
 ### Changed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.0.4] - 2025-11-03
 ### Changed
 - Update `@subql/common`, `@subql/node-core`  (#161)
 
@@ -314,7 +316,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synced latest changes from main repo. (#10)
 
 ## [1.6.0] - 2022-08-04
-[Unreleased]: https://github.com/subquery/subql-algorand/compare/node-algorand/4.0.3...HEAD
+[Unreleased]: https://github.com/subquery/subql-algorand/compare/node-algorand/4.0.4...HEAD
+[4.0.4]: https://github.com/subquery/subql-algorand/compare/node-algorand/4.0.3...node-algorand/4.0.4
 [4.0.3]: https://github.com/subquery/subql-algorand/compare/node-algorand/4.0.2...node-algorand/4.0.3
 [4.0.2]: https://github.com/subquery/subql-algorand/compare/node-algorand/4.0.1...node-algorand/4.0.2
 [4.0.1]: https://github.com/subquery/subql-algorand/compare/node-algorand/4.0.0...node-algorand/4.0.1

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/node-algorand",
-  "version": "4.0.4-1",
+  "version": "4.0.4",
   "description": "",
   "author": "Ian He",
   "license": "GPL-3.0",
@@ -62,6 +62,5 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE"
-  ],
-  "stableVersion": "4.0.4-0"
+  ]
 }

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@subql/types-core` (#161)
 
 ## [4.1.1] - 2025-07-01
 ### Changed

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.1.2] - 2025-11-03
 ### Changed
 - Update `@subql/types-core` (#161)
 
@@ -99,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.1] - 2022-08-04
 
 ## [1.2.0] - 2022-08-04
-[Unreleased]: https://github.com/subquery/subql-algorand/compare/types-algorand/4.1.1...HEAD
+[Unreleased]: https://github.com/subquery/subql-algorand/compare/types-algorand/4.1.2...HEAD
+[4.1.2]: https://github.com/subquery/subql-algorand/compare/types-algorand/4.1.1...types-algorand/4.1.2
 [4.1.1]: https://github.com/subquery/subql-algorand/compare/types-algorand/4.1.0...types-algorand/4.1.1
 [4.1.0]: https://github.com/subquery/subql-algorand/compare/types-algorand/4.0.1...types-algorand/4.1.0
 [4.0.1]: https://github.com/subquery/subql-algorand/compare/types-algorand/3.6.1...types-algorand/4.0.1

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/types-algorand",
-  "version": "4.1.2-0",
+  "version": "4.1.2",
   "description": "",
   "homepage": "https://github.com/subquery/subql",
   "repository": "github:subquery/subql-algorand",
@@ -34,6 +34,5 @@
   },
   "dependencies": {
     "@subql/types-core": "^2.2.0"
-  },
-  "stableVersion": "4.1.1"
+  }
 }


### PR DESCRIPTION
- **[release] 20251103**
- **Update versions**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released stable versions across multiple packages: common-algorand (4.4.4), node (4.0.4), and types (4.1.2).
  * Updated changelog documentation with new release information and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->