### PR TITLE
Fix cached blocks causing a mutation which would break retries

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Cache mutation potentially causing blocks to be skipped (#165)
 
 ## [4.0.5] - 2025-11-05
 ### Changed

--- a/packages/node/src/algorand/algorand.spec.ts
+++ b/packages/node/src/algorand/algorand.spec.ts
@@ -5,7 +5,6 @@ import { INestApplication } from '@nestjs/common';
 import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
 import { Test } from '@nestjs/testing';
 import {
-  ApiService,
   ConnectionPoolService,
   ConnectionPoolStateManager,
   NodeConfig,

--- a/packages/node/src/algorand/algorand.spec.ts
+++ b/packages/node/src/algorand/algorand.spec.ts
@@ -10,6 +10,7 @@ import {
   ConnectionPoolStateManager,
   NodeConfig,
 } from '@subql/node-core';
+import { AlgorandBlock } from '@subql/types-algorand';
 import { GraphQLSchema } from 'graphql';
 import { AlgorandApiService, filterTransaction } from '../algorand';
 import { SubqueryProject } from '../configure/SubqueryProject';
@@ -67,13 +68,6 @@ export const prepareApiService = async (
 
 jest.setTimeout(90000);
 describe('Algorand RPC', () => {
-  let app: INestApplication;
-  let apiService: ApiService;
-
-  afterEach(() => {
-    return app?.close();
-  });
-
   it('Can filter acfg with sender', () => {
     const tx = {
       assetConfigTransaction: {
@@ -125,43 +119,89 @@ describe('Algorand RPC', () => {
     ).toBe(true);
   });
 
-  // This is failing since switching from algo explorer api. This is due to a node configuration limit
-  it('paginate large blocks', async () => {
-    [app, apiService] = await prepareApiService(
-      testnetEndpoint,
-      testnetChainId,
-    );
-    const failingBlock = 27739202; // testnet
-    const api = apiService.api;
+  describe('testnet data', () => {
+    let app: INestApplication;
+    let apiService: AlgorandApiService;
 
-    const paginateSpy = jest.spyOn(api, 'paginatedTransactions');
-    const result = await api.getBlockByHeight(failingBlock);
-    expect(paginateSpy).toHaveBeenCalledTimes(3);
-    expect(result.transactions.length).toEqual(13916);
+    beforeEach(async () => {
+      [app, apiService] = await prepareApiService(
+        testnetEndpoint,
+        testnetChainId,
+      );
+    });
+
+    afterEach(() => {
+      return app?.close();
+    });
+
+    // This is failing since switching from algo explorer api. This is due to a node configuration limit
+    it('paginate large blocks', async () => {
+      const failingBlock = 27739202; // testnet
+      const api = apiService.api;
+
+      const paginateSpy = jest.spyOn(api, 'paginatedTransactions');
+      const result = await api.getBlockByHeight(failingBlock);
+      expect(paginateSpy).toHaveBeenCalledTimes(3);
+      expect(result.transactions?.length).toEqual(13916);
+    });
+
+    // There was a bug that would cause block nums to be mutated, when a network request failed, it would result in the retry missing blocks because of the mutation
+    it('block caching doesnt mutate the block nums', async () => {
+      const blockHeight = 57397158;
+
+      const blockNums = [blockHeight];
+
+      // Get the previous block, it will fetch the next block to get the hash of the current block.
+      await apiService.api.fetchBlocks([blockHeight - 1]);
+      // This block should hit the cache because of the previous request
+      const [block1] = await apiService.api.fetchBlocks(blockNums);
+      // The cache should have cleared the previous block, so this fetch is fresh
+      const [block2] = await apiService.api.fetchBlocks(blockNums);
+
+      // Block nums should not be mutated
+      expect(blockNums).toEqual([blockHeight]);
+
+      expect(block1).toBeDefined();
+      expect(block2).toBeDefined();
+
+      expect(JSON.stringify(block1)).toEqual(JSON.stringify(block2));
+    });
   });
 
-  it('can stringify blocks and transactions with circular references', async () => {
-    [app, apiService] = await prepareApiService();
+  describe('mainnet data', () => {
+    let app: INestApplication;
+    let apiService: AlgorandApiService;
+    let block: AlgorandBlock;
 
-    const block = await apiService.api.getBlockByHeight(30478896);
+    beforeEach(async () => {
+      [app, apiService] = await prepareApiService();
 
-    // The circular ref
-    expect(block.transactions[13].block).toBeDefined();
+      block = await apiService.api.getBlockByHeight(30478896);
+    });
 
-    // We can stringify the objects
-    expect(() => JSON.stringify(block)).not.toThrow();
-    expect(() => JSON.stringify(block.transactions[13])).not.toThrow();
+    afterEach(() => {
+      return app?.close();
+    });
 
-    expect(JSON.parse(JSON.stringify(block)).round).toEqual(block.round);
-  });
+    it('can stringify blocks and transactions with circular references', () => {
+      const transaction = block.transactions![13];
 
-  it('can get the grouped transactions within a block', async () => {
-    [app, apiService] = await prepareApiService();
+      // The circular ref
+      expect(transaction.block).toBeDefined();
 
-    const block = await apiService.api.getBlockByHeight(30478896);
+      // We can stringify the objects
+      expect(() => JSON.stringify(block)).not.toThrow();
+      expect(() => JSON.stringify(transaction)).not.toThrow();
 
-    const groupTx = block.getTransactionsByGroup(block.transactions[13].group);
+      expect(JSON.parse(JSON.stringify(block)).round).toEqual(block.round);
+    });
 
-    expect(groupTx.length).toEqual(3);
+    it('can get the grouped transactions within a block', () => {
+      const groupTx = block.getTransactionsByGroup(
+        block.transactions![13].group!,
+      );
+
+      expect(groupTx.length).toEqual(3);
+    });
   });
 });

--- a/packages/node/src/algorand/api.algorand.ts
+++ b/packages/node/src/algorand/api.algorand.ts
@@ -67,9 +67,7 @@ export class AlgorandApi {
     try {
       const blockInfo = await this.api.lookupBlock(height).do();
 
-      const block = this.constructBlock(camelCaseObjectKey(blockInfo));
-
-      return block;
+      return this.constructBlock(camelCaseObjectKey(blockInfo));
     } catch (error: any) {
       if (error.message.includes('Max transactions limit exceeded')) {
         logger.warn('Max transactions limit exceeded, paginating transactions');


### PR DESCRIPTION
# Description
Fixes an issue where blocks would not be indexed if fetching failed because of caching blocks.

Because there is a need to look ahead to the next block, to get the previous block hash there is a cache to optimise network requests.
When this cache was hit, it would mutate the block numbers input, this is fine when all network requests work but if there is a failure then it would retry with the same block numbers, except it was mutated to exclude the blocks from the cache.



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * More concurrent, cache-aware block fetching for faster, more reliable data retrieval.
* **Tests**
  * Reorganized suite with per-dataset isolation and lifecycle hooks for improved reliability.
* **Bug Fixes**
  * Fixed cache mutation that could skip blocks.
* **Chores**
  * Updated changelog with the cache-fix entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->